### PR TITLE
Update android-whitelist.json

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -2259,7 +2259,8 @@
     },
     {
       "allows_granular_projects": [
-        "com.mercadolibre.android.local.storage"
+        "com.mercadolibre.android.local.storage",
+        "com.mercadopago.android.isp.point.mpoc.mpp"
       ],
       "group": "androidx\\.security",
       "name": "security-crypto",


### PR DESCRIPTION
# Descripción

Solicitamos agregar a my pin pad para el uso de `androidx.security` ya que es mandatoria para el uso del sdk del tercero, esto nos generó un error en [bugsnag ](https://app.bugsnag.com/mercadolibre/mercado-pago-android/errors/66f5fe278661532aee0d6d8b?filters[app.release_stage][]=release&filters[event.before]=2024-09-30T18%3A00%3A00.000Z&filters[event.since]=2024-09-29T18%3A00%3A00.000Z&pivot_tab=event)

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [x] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store

## Mi dependencia es:
- [ ] Interna: Libreria/modulo desarrollado in-house en base al ecosistema de Meli.
- [ ] Externa: Libreria desarrollada por un externo a Meli. (Google, Airbnb, otros).

## La categoría de la dependencia es:
- [ ] Frontend
- [ ] Cross

    Para más información sobre la categoria mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#libreria-frontend-x-cross)

## Mi dependencia tienes un uso controlado:
- [ ] Si
- [ ] No
    
    Para más información sobre el uso controlado mirar [Readme](https://github.com/mercadolibre/mobile-dependencies_whitelist/blob/feature/update-readme-frontend-cross/README.md#support-for-granular-dependencies)

## En caso de ser una dependencia interna, se ha agregado una lib .aar o framework (iOS) en nexus sobre el proyecto?
- [ ] Si, adjuntar link a nexus.
- [ ] No
